### PR TITLE
Legg til routing for Innsyn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,48 @@
-# Søknad om økonomisk sosialhjelp - test proxy
+# Test-proxy for økonomisk sosialhjelp
 
-Reverse proxy for åpne testapplikasjoner.
+Reverse proxy for testing av applikasjoner for økonomisk sosialhjelp
+
+### Formål
+
+Formålet med proxy-en er å gjøre det enkelt å sette opp mockede applikasjoner på
+Heroku for manuell ekstern testing og automatisert nettlesertesting i byggejobber. I
+tillegg er den en avlastning for interne miljøer, da kodeendringer som ikke berører
+integrasjoner mot andre tjenester kan testes ute i et miljø, uten å legge beslag på
+et av de få faste testmiljøene.
+
+### Deployment
+
+Ved første deployment til en ny applikasjon på Heroku, må vi fortelle Heroku hva slags
+applikasjon som skal deployes. Denne applikasjonen er en Docker-container, og vi bruker
+derfor følgende kommando:
+
+```
+heroku stack:set container
+```
+
+Det vil deretter være mulig å knytte applikasjonen på Heroku til dette repoet i navikt-
+organisasjonen og deploye fra Heroku dashboardet.
+
+### Routing
+
+For hver tjeneste defineres det en default frontend og backend:
+
+- `https://digisos-test.com/soknadsosialhjelp/` -> `https://soknadsosialhjelp.herokuapp.com/soknadsosialhjelp/`
+- `https://digisos-test.com/soknadsosialhjelp-server/` -> `https://soknadsosialhjelp-server.herokuapp.com/soknadsosialhjelp-server/`
+
+I tillegg defineres en omskrivningsregel for å koble frontend og backend i et
+vilkårlig antall dynamiske "miljøer":
+
+- `https://digisos-test.com/en-ny-feature/soknadsosialhjelp/` -> `https://en-ny-feature.herokuapp.com/soknadsosialhjelp/`
+- `https://digisos-test.com/en-ny-feature/soknadsosialhjelp-server/` -> `https://en-ny-feature-server.herokuapp.com/soknadsosialhjelp-server/`
+
+(En forutsetning for at dette skal virke er at applikasjonene er context path-agnostiske.)
+
+For å slippe å bygge en ny backend ved endringer kun i frontend, routes kall mot frontend
+prefixet med `-/` mot default backend:
+
+- `https://digisos-test.com/-/en-ny-feature/soknadsosialhjelp/` -> `https://en-ny-feature.herokuapp.com/soknadsosialhjelp/`
+- `https://digisos-test.com/-/en-ny-feature/soknadsosialhjelp-server/` -> `https://soknadsosialhjelp-server.herokuapp.com/soknadsosialhjelp-server/`
+
+(**TODO**: Dette må også implementeres i resolving av API-path frontend, og er foreløpig
+kun implementert med vanlig omskrivningsregel.)

--- a/default.conf
+++ b/default.conf
@@ -6,22 +6,32 @@ server {
 	    return 301 https://$server_name$request_uri;
     }
 
+    # Default innsyn API
+    location /soknadsosialhjelp/innsyn-api/ {
+        proxy_set_header Host innsyn-test-server.herokuapp.com;
+        proxy_pass https://innsyn-test-server.herokuapp.com/soknadsosialhjelp/innsyn-api/;
+    }
+
+    # Default innsyn frontend
+    location /soknadsosialhjelp/innsyn/ {
+        proxy_set_header Host innsyn-test.herokuapp.com;
+        proxy_pass https://innsyn-test.herokuapp.com/soknadsosialhjelp/innsyn/;
+    }
+
+    # Default søknad API
     location /soknadsosialhjelp-server/ {
         proxy_set_header Host sosialhjelp-api-test.herokuapp.com;
         proxy_pass https://sosialhjelp-api-test.herokuapp.com/soknadsosialhjelp-server/;
     }
 
-    location /soknadsosialhjelp/innsyn/ {
-        proxy_set_header Host sosialhjelp-innsyn.herokuapp.com;
-        proxy_pass https://sosialhjelp-innsyn.herokuapp.com/;
-    }
-
+    # Default søknad frontend
     location /soknadsosialhjelp/ {
         proxy_set_header Host sosialhjelp-test.herokuapp.com;
         proxy_pass https://sosialhjelp-test.herokuapp.com/soknadsosialhjelp/;
     }
 
-    location ~* ^/(?<app>[^/]+)/soknadsosialhjelp(?<context>-server)?/(?<path>.+)$ {
+    # TODO: Resolve default backend in proxy
+    location ~* ^(/-)?/(?<app>[^/]+)/soknadsosialhjelp(?<context>-server)?/(?<path>.+)$ {
         resolver 8.8.8.8;
         proxy_set_header Host $app$context.herokuapp.com;
         proxy_pass https://$app$context.herokuapp.com/soknadsosialhjelp$context/$path?$args;


### PR DESCRIPTION
Proxyen er deployet i test-miljø:

Søknad frontend: https://sosialhjelp-test-proxy.herokuapp.com/soknadsosialhjelp/informasjon
Sønad API: https://sosialhjelp-test-proxy.herokuapp.com/soknadsosialhjelp-server/internal/isAlive
Innsyn frontend: https://sosialhjelp-test-proxy.herokuapp.com/soknadsosialhjelp/innsyn/
Innsyn API: https://sosialhjelp-test-proxy.herokuapp.com/soknadsosialhjelp/innsyn-api/internal/isAlive

Vil være tilgjengelig under https://www.digisos-test.com/ etter deployment til Joachims test proxy.

Default-URL-ene bør rettes opp til felles-appene. (jeg husker ikke passord sånn at jeg får sjekka.)