### PR TITLE
DIGISOS-1329: Legg til regex pattern for Innsyn frontend+backend

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -31,4 +31,16 @@ server {
         proxy_set_header Host $app$context.herokuapp.com;
         proxy_pass https://$app$context.herokuapp.com/soknadsosialhjelp$context/$path?$args;
     }
+
+    location ~* ^/(?<app>[^/]+)/sosialhjelp/innsyn-api/(?<path>.*)$ {
+        resolver 8.8.8.8;
+        proxy_set_header Host $app-server.herokuapp.com;
+        proxy_pass https://$app-server.herokuapp.com/soknadsosialhjelp/innsyn-api/$path;
+    }
+
+    location ~* ^/(?<app>[^/]+)/sosialhjelp/innsyn/(?<path>.*)$ {
+        resolver 8.8.8.8;
+        proxy_set_header Host $app.herokuapp.com;
+        proxy_pass https://$app.herokuapp.com/$path;
+    }
 }

--- a/default.conf
+++ b/default.conf
@@ -7,8 +7,8 @@ server {
     }
 
     location /soknadsosialhjelp-server/ {
-        proxy_set_header Host sosialhjelp-api-test.herokuapp.com;
-        proxy_pass https://sosialhjelp-api-test.herokuapp.com/soknadsosialhjelp-server/;
+        proxy_set_header Host sosialhjelp-soknad-server.herokuapp.com;
+        proxy_pass https://sosialhjelp-soknad-server.herokuapp.com/soknadsosialhjelp-server/;
     }
 
     location /sosialhjelp/innsyn/ {
@@ -22,8 +22,8 @@ server {
     }
 
     location /soknadsosialhjelp/ {
-        proxy_set_header Host sosialhjelp-test.herokuapp.com;
-        proxy_pass https://sosialhjelp-test.herokuapp.com/soknadsosialhjelp/;
+        proxy_set_header Host sosialhjelp-soknad.herokuapp.com;
+        proxy_pass https://sosialhjelp-soknad.herokuapp.com/soknadsosialhjelp/;
     }
 
     location ~* ^/(?<app>[^/]+)/soknadsosialhjelp(?<context>-server)?/(?<path>.+)$ {


### PR DESCRIPTION
Legg til pattern for ekstra testmiljøer på innsyn.

Testet routing fra https://fleskesvor-test-proxy.herokuapp.com/:

Gamle:
https://fleskesvor-test-proxy.herokuapp.com/soknadsosialhjelp/informasjon
https://fleskesvor-test-proxy.herokuapp.com/soknadsosialhjelp-server/internal/isAlive
https://fleskesvor-test-proxy.herokuapp.com/fleskesvor/soknadsosialhjelp/informasjon
https://fleskesvor-test-proxy.herokuapp.com/fleskesvor/soknadsosialhjelp-server/internal/isAlive
https://fleskesvor-test-proxy.herokuapp.com/sosialhjelp/innsyn/
https://fleskesvor-test-proxy.herokuapp.com/sosialhjelp/innsyn-api/internal/isAlive

Nye (går mot innsyn-test.herokuapp.com og innsyn-test-server.herokuapp.com):
https://fleskesvor-test-proxy.herokuapp.com/innsyn-test/sosialhjelp/innsyn/
https://fleskesvor-test-proxy.herokuapp.com/innsyn-test/sosialhjelp/innsyn-api/internal/isAlive

De nye er i tillegg avhengig av endringer i innsyn frontend som jeg lager PR på.